### PR TITLE
Add a contact entry to the footer

### DIFF
--- a/data.json
+++ b/data.json
@@ -42,6 +42,10 @@
       "link": "https://gitter.im/resin-io/etcher"
     },
     {
+      "title": "Contact",
+      "link": "mailto:hello@etcher.io"
+    },
+    {
       "title": "About Us",
       "link": "https://resin.io"
     },

--- a/index.html
+++ b/index.html
@@ -237,6 +237,8 @@
                 
                   <li><a data-track-id="bottomNav button" data-toggle="modal" data-target="" data-track="[etcher website] link click" data-track-attrs='{"title":"Chat on gitter","link":"https://gitter.im/resin-io/etcher"}' target="_blank" href="https://gitter.im/resin-io/etcher">Chat on gitter</a></li>
                 
+                  <li><a data-track-id="bottomNav button" data-toggle="modal" data-target="" data-track="[etcher website] link click" data-track-attrs='{"title":"Contact","link":"mailto:hello@etcher.io"}' target="_blank" href="mailto:hello@etcher.io">Contact</a></li>
+                
                   <li><a data-track-id="bottomNav button" data-toggle="modal" data-target="" data-track="[etcher website] link click" data-track-attrs='{"title":"About Us","link":"https://resin.io"}' target="_blank" href="https://resin.io">About Us</a></li>
                 
                   <li><a data-track-id="bottomNav button" data-toggle="modal" data-target="" data-track="[etcher website] link click" data-track-attrs='{"title":"Blog","link":"https://resin.io/blog"}' target="_blank" href="https://resin.io/blog">Blog</a></li>


### PR DESCRIPTION
This entry points to our brand new hello@etcher.io email address.

<img width="215" alt="screenshot 2017-04-05 17 13 50" src="https://cloud.githubusercontent.com/assets/2192773/24727331/960eddb6-1a23-11e7-8558-1772ff7ce59f.png">

Fixes: https://github.com/resin-io/etcher-homepage/issues/30
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>