### PR TITLE
Fix iframe `height` attribute

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -36,7 +36,7 @@ export default class extends Component {
           <div className="share mb-5">
             <Share url={locals.website} />
             <div>
-              <iframe src={`https://ghbtns.com/github-btn.html?user=resin-io&repo=${locals.title.toLowerCase()}&type=star&count=true`} scrolling="0" width="100" height="20px"></iframe>
+              <iframe src={`https://ghbtns.com/github-btn.html?user=resin-io&repo=${locals.title.toLowerCase()}&type=star&count=true`} scrolling="0" width="100" height="20"></iframe>
             </div>
           </div>
           <div className="screenshot">


### PR DESCRIPTION
According to https://validator.w3.org/nu/?doc=https%3A%2F%2Fetcher.io%2F  `height="20px"` is invalid.

However I know almost nothing about CSS, so perhaps the validator is being overly strict and my suggested change here is incorrect?