### PR TITLE
feat: make tweet more descriptive and add link

### DIFF
--- a/pages/success-banner.js
+++ b/pages/success-banner.js
@@ -26,7 +26,7 @@ const Banner = () => (
         <img className="icon github" src="/static/social/octocat.png" />
         Star on Github
       </Button>
-      <Button href="https://twitter.com/intent/tweet?text=Just%20flashed%20an%20image%20with%20%23etcher%20http%3A%2F%2Fetcher.io%20by%20%40resin_io%20and...">
+      <Button href="https://twitter.com/intent/tweet?text=Just%20flashed%20an%20image%20with%20%23etcher%20https%3A%2F%2Fetcher.io%20by%20%40resin_io%20and...">
         <img className="icon twitter" src="/static/social/twitter.png" />
         Tweet
       </Button>

--- a/pages/success-banner.js
+++ b/pages/success-banner.js
@@ -26,7 +26,7 @@ const Banner = () => (
         <img className="icon github" src="/static/social/octocat.png" />
         Star on Github
       </Button>
-      <Button href="https://twitter.com/intent/tweet?text=I%20just%20flashed%20an%20image%20with%20%23etcher%20by%20%40resin_io%2C%20safe%20%26%20easy!%20https%3A%2F%2Fetcher.io">
+      <Button href="https://twitter.com/intent/tweet?text=Just%20flashed%20an%20image%20with%20%23etcher%20by%20%40resin_io%20and...%20http%3A%2F%2Fetcher.io">
         <img className="icon twitter" src="/static/social/twitter.png" />
         Tweet
       </Button>

--- a/pages/success-banner.js
+++ b/pages/success-banner.js
@@ -26,7 +26,7 @@ const Banner = () => (
         <img className="icon github" src="/static/social/octocat.png" />
         Star on Github
       </Button>
-      <Button href="https://twitter.com/intent/tweet?text=%23etcher">
+      <Button href="https://twitter.com/intent/tweet?text=I%20just%20flashed%20an%20image%20with%20%23etcher%20by%20%40resin_io%2C%20safe%20%26%20easy!%20https%3A%2F%2Fetcher.io">
         <img className="icon twitter" src="/static/social/twitter.png" />
         Tweet
       </Button>

--- a/pages/success-banner.js
+++ b/pages/success-banner.js
@@ -26,7 +26,7 @@ const Banner = () => (
         <img className="icon github" src="/static/social/octocat.png" />
         Star on Github
       </Button>
-      <Button href="https://twitter.com/intent/tweet?text=Just%20flashed%20an%20image%20with%20%23etcher%20by%20%40resin_io%20and...%20http%3A%2F%2Fetcher.io">
+      <Button href="https://twitter.com/intent/tweet?text=Just%20flashed%20an%20image%20with%20%23etcher%20http%3A%2F%2Fetcher.io%20by%20%40resin_io%20and...">
         <img className="icon twitter" src="/static/social/twitter.png" />
         Tweet
       </Button>


### PR DESCRIPTION
We change the Tweet from solely being a hashtag to something more descriptive,
including links to the Resin Twitter account and Etcher website.