### PR TITLE
Add googletag manager

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -34,7 +34,7 @@ const locals = {
     gaId: 'UA-45671959-2',
     gosquaredId: 'GSN-954701-N',
     prefix: 'Etcher Website',
-    tagManagerId: 'GTM-5Z53V35'
+    tagManagerId: 'GTM-WPMGNJJ'
   },
   nav: {
     header: pick(links, [ 'Repository', 'Changelog' , 'CLI', 'Chat', 'Mailing List', 'Help']),

--- a/config/index.js
+++ b/config/index.js
@@ -33,7 +33,8 @@ const locals = {
     gaSite: 'etcher.io',
     gaId: 'UA-45671959-2',
     gosquaredId: 'GSN-954701-N',
-    prefix: 'Etcher Website'
+    prefix: 'Etcher Website',
+    tagManagerId: 'GTM-5Z53V35'
   },
   nav: {
     header: pick(links, [ 'Repository', 'Changelog' , 'CLI', 'Chat', 'Mailing List', 'Help']),

--- a/lib/getLatestRelease.js
+++ b/lib/getLatestRelease.js
@@ -12,7 +12,11 @@ if (process.env.GH_TOKEN) {
 }
 
 const getOS = str => {
-  if (includes(str, 'darwin') || includes(str, '.dmg') || includes(str, 'mac')) {
+  if (
+    includes(str, 'darwin') ||
+    includes(str, '.dmg') ||
+    includes(str, 'mac')
+  ) {
     return 'macOS';
   } else if (includes(str, 'win32') || includes(str, '.exe')) {
     return 'Windows';
@@ -96,12 +100,13 @@ const prepAssets = assets => {
       // Omit OS X ZIP files (used for update purposes)
       // Omit electron packages
       return !(
-        (includes(item.name, '.zip') && getOS(item.name.toLowerCase()) === 'macOS') ||
+        (includes(item.name, '.zip') &&
+          getOS(item.name.toLowerCase()) === 'macOS') ||
         includes(item.name, 'electron')
       );
     })
     .map(item => {
-      const str = item.name.toLowerCase()
+      const str = item.name.toLowerCase();
       return {
         text: packagePrettyName(str),
         href: item.browser_download_url,

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -1,0 +1,12 @@
+export const tagManagerHead = (tagManagerId) => `<!-- Google Tag Manager -->
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${tagManagerId}');
+<!-- End Google Tag Manager -->`
+
+export const tagManagerNoScript = (tagManagerId) => `<!-- Google Tag Manager (noscript) -->
+<iframe src="https://www.googletagmanager.com/ns.html?id=${tagManagerId}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe>
+<!-- End Google Tag Manager (noscript) -->`

--- a/pages/_Layout.js
+++ b/pages/_Layout.js
@@ -9,12 +9,19 @@ import { Tracker, Locals } from './_Providers';
 import 'babel-polyfill';
 import '../lib/raven';
 
+import { tagManagerHead, tagManagerNoScript } from '../lib/scripts';
+
 export default class extends Component {
   render() {
     return (
       <Tracker analytics={this.props.analytics}>
         <div>
           <Head>
+            <script
+              dangerouslySetInnerHTML={{
+                __html: tagManagerHead(this.props.analytics.tagManagerId)
+              }}
+            />
             <title>
               {this.props.title}
             </title>
@@ -46,6 +53,11 @@ export default class extends Component {
             <Typekit kitId={this.props.typekitId} />
             <link rel="stylesheet" type="text/css" href="/static/index.css" />
           </Head>
+          <noscript
+            dangerouslySetInnerHTML={{
+              __html: tagManagerNoScript(this.props.analytics.tagManagerId)
+            }}
+          />
           <Nav
             color="inverse"
             inverse

--- a/pages/index.js
+++ b/pages/index.js
@@ -117,8 +117,8 @@ export default class extends Component {
             Looking for{' '}
             <a href="https://github.com/resin-io/etcher#debian-and-ubuntu-based-package-repository-gnulinux-x86x64">
               Debian (.deb) packages
-            </a>
-            {' '}or{' '}
+            </a>{' '}
+            or{' '}
             <a href="https://github.com/resin-io/etcher#redhat-rhel-and-fedora-based-package-repository-gnulinux-x86x64">
               Red Hat (.rpm) packages
             </a>


### PR DESCRIPTION
Connects to #101 
This allows us to remotely analytics scripts like fb pixel, google Optimize etc.
(I also ran `npm run prettier` so there are a couple extra linting changes in this PR.)

Change-Type: patch