### PR TITLE
github fetcher for 1.2.0

### DIFF
--- a/lib/getLatestRelease.js
+++ b/lib/getLatestRelease.js
@@ -102,7 +102,8 @@ const prepAssets = assets => {
       return !(
         (includes(item.name, '.zip') &&
           getOS(item.name.toLowerCase()) === 'macOS') ||
-        includes(item.name, 'electron')
+        includes(item.name, 'electron') ||
+        includes(item.name, 'SHASUMS256')
       );
     })
     .map(item => {


### PR DESCRIPTION
A new file `SHASUMS256.txt` was added with `1.2.0` we should filter it from the download lists.