### PR TITLE
ci: Set package private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "etcher.io",
+  "private": true,
   "version": "1.1.6",
   "description": "react based static site",
   "author": "Resin.io Ltd (https://resin.io)",


### PR DESCRIPTION
This will stop ResinCI from trying to upload this as an npm module.

Change-type: patch
Signed-off-by: Jack Brown <jack@resin.io>